### PR TITLE
chore: remove subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "sideEffects": false,
   "exports": {
-    "./package.json": "./package.json",
     ".": {
       "import": "./dist/untyped.mjs",
       "require": "./dist/untyped.js"


### PR DESCRIPTION
This will address the Node 16+ deprecation warning:
```
(node:98300) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /node_modules/untyped/package.json.
Update this package.json to use a subpath pattern like "./*"
```

We could use `"./*": "./*"` instead but it looks like we don't have anything else we aren't explicitly making available: https://unpkg.com/browse/untyped@0.2.5/dist/ (In this case I think being explicit is probably best.)
