### PR TITLE
fix: cache babel loader based on untyped version

### DIFF
--- a/src/loader/babel.ts
+++ b/src/loader/babel.ts
@@ -1,11 +1,15 @@
-import type { PluginObj } from '@babel/core'
+import type { ConfigAPI, PluginItem, PluginObj } from '@babel/core'
 import * as t from '@babel/types'
 import { Schema, JSType, TypeDescriptor, FunctionArg } from '../types'
 import { normalizeTypes, mergedTypes, cachedFn } from '../utils'
 
+import { version } from '../../package.json'
+
 type GetCodeFn = (loc: t.SourceLocation) => string
 
-export default function babelPluginUntyped () {
+export default <PluginItem> function babelPluginUntyped (api: ConfigAPI) {
+  api.cache.using(() => version)
+
   return <PluginObj>{
     visitor: {
       VariableDeclaration (p) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "moduleResolution": "Node",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "strict": false,
     "types": [


### PR DESCRIPTION
At the moment changes to `untyped` can have no effect for some time as the Babel cache continues returning old transform results.