### PR TITLE
fix: preserve spacing at beginnings of lines

### DIFF
--- a/src/loader/babel.ts
+++ b/src/loader/babel.ts
@@ -124,7 +124,7 @@ function containsIncompleteCodeblock (line = '') {
   return !!(codeDelimiters % 2)
 }
 
-function clumpLines (lines: string[], delimiters = [], separator = ' ') {
+function clumpLines (lines: string[], delimiters = [' '], separator = ' ') {
   const clumps: string[] = []
   while (lines.length) {
     const line = lines.shift()
@@ -148,7 +148,7 @@ function parseJSDocs (input: string | string[]): Schema {
   }
 
   const lines = ([] as string[]).concat(input)
-    .map(c => c.split('\n').map(l => l.replace(/^[\s*]+|[\s*]$/, '')))
+    .map(c => c.split('\n').map(l => l.replace(/(^\s*[*]+ )|([\s*]+$)/g, '')))
     .flat()
 
   const firstTag = lines.findIndex(l => l.startsWith('@'))


### PR DESCRIPTION
resolves #15

[reproduction](https://a6cbb7e2.untyped.pages.dev/#eyJlZGl0b3JUYWIiOiJyZWZlcmVuY2UiLCJvdXRwdXRUYWIiOiJ0eXBlcyIsInJlZiI6ImV4cG9ydCBjb25zdCBjb25maWcgPSB7XG4gICAgLyoqXG4gICAgICogU29tZXRoaW5nXG4gICAgICogXG4gICAgICogICAtIEFcbiAgICAgKiAgICAgLSBCXG4gICAgICogXG4gICAgICogQGV4YW1wbGVcbiAgICAgKiB7XG4gICAgICogICAgYmFyOiAnYmF6J1xuICAgICAqIH1cbiAgICAgKi9cbiAgICBmb286IHt9LFxufSIsImlucHV0IjoiZXhwb3J0IGNvbnN0IGNvbmZpZyA9IHtcbiAgICBuYW1lOiAnZm9vJyxcbiAgICBkaW1lbnNpb25zOiB7XG4gICAgICAgIGhlaWdodDogMjVcbiAgICB9LFxuICAgIHRhZ3M6IFsnY3VzdG9tJ11cbn0ifQ==)