### PR TITLE
feat: `tsType`, `type` and `markdownType`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,14 +45,12 @@
     "marked": "latest",
     "monaco-editor": "latest",
     "prismjs": "latest",
+    "scule": "latest",
     "siroc": "latest",
     "standard-version": "latest",
     "ts-jest": "latest",
     "vite": "latest",
     "vite-plugin-windicss": "^0.9.5",
     "vue": "3"
-  },
-  "dependencies": {
-    "scule": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "vite": "latest",
     "vite-plugin-windicss": "^0.9.5",
     "vue": "3"
+  },
+  "dependencies": {
+    "scule": "^0.2.1"
   }
 }

--- a/src/generator/dts.ts
+++ b/src/generator/dts.ts
@@ -67,7 +67,13 @@ function getTsType (type: TypeDescriptor | TypeDescriptor[]): string {
   if (Array.isArray(type)) {
     return [].concat(normalizeTypes(type.map(t => getTsType(t)))).join('|') || 'any'
   }
-  if (!type || !type.type) {
+  if (!type) {
+    return 'any'
+  }
+  if (type.tsType) {
+    return type.tsType
+  }
+  if (!type.type) {
     return 'any'
   }
   if (Array.isArray(type.type)) {
@@ -89,7 +95,7 @@ export function genFunctionArgs (args: Schema['args']) {
     if (arg.optional || arg.default) {
       argStr += '?'
     }
-    if (arg.type) {
+    if (arg.type || arg.tsType) {
       argStr += `: ${getTsType(arg)}`
     }
     return argStr

--- a/src/generator/dts.ts
+++ b/src/generator/dts.ts
@@ -22,6 +22,8 @@ const SCHEMA_KEYS = [
   'description',
   '$schema',
   'type',
+  'tsType',
+  'markdownType',
   'tags',
   'args',
   'id',

--- a/src/generator/md.ts
+++ b/src/generator/md.ts
@@ -10,7 +10,7 @@ export function _generateMarkdown (schema: Schema, title: string, level: string)
 
   lines.push(`${level} ${title}`)
 
-  if ('properties' in schema) {
+  if (schema.type === 'object') {
     for (const key in schema.properties) {
       const val = schema.properties[key] as Schema
       lines.push('', ..._generateMarkdown(val, `\`${key}\``, level + '#'))
@@ -19,7 +19,7 @@ export function _generateMarkdown (schema: Schema, title: string, level: string)
   }
 
   // Type and default
-  lines.push(`- **Type**: \`${schema.type}\``)
+  lines.push(`- **Type**: \`${schema.markdownType || schema.tsType || schema.type}\``)
   if ('default' in schema) {
     lines.push(`- **Default**: \`${JSON.stringify(schema.default)}\``)
   }

--- a/src/loader/babel.ts
+++ b/src/loader/babel.ts
@@ -229,7 +229,7 @@ function astify (val: any) {
   )
 }
 
-const AST_JSTYPE_MAP: Partial<Record<t.Expression['type'], JSType>> = {
+const AST_JSTYPE_MAP: Partial<Record<t.Expression['type'], JSType | 'RegExp'>> = {
   StringLiteral: 'string',
   BooleanLiteral: 'boolean',
   BigIntLiteral: 'bigint',
@@ -237,15 +237,13 @@ const AST_JSTYPE_MAP: Partial<Record<t.Expression['type'], JSType>> = {
   NumericLiteral: 'number',
   ObjectExpression: 'object',
   FunctionExpression: 'function',
-  ArrowFunctionExpression: 'function'
-  // RegExpLiteral: 'RegExp'
+  ArrowFunctionExpression: 'function',
+  RegExpLiteral: 'RegExp'
 }
 
 function inferArgType (e: t.Expression, getCode: GetCodeFn): TypeDescriptor {
   if (AST_JSTYPE_MAP[e.type]) {
-    return {
-      type: AST_JSTYPE_MAP[e.type]
-    }
+    return getTypeDescriptor(AST_JSTYPE_MAP[e.type])
   }
   if (e.type === 'AssignmentExpression') {
     return inferArgType(e.right, getCode)

--- a/src/loader/babel.ts
+++ b/src/loader/babel.ts
@@ -188,7 +188,13 @@ function parseJSDocs (input: string | string[]): Schema {
     const tags = clumpLines(lines.slice(firstTag), ['@'], '\n')
     for (const tag of tags) {
       if (tag.startsWith('@type')) {
-        Object.assign(schema, getTypeDescriptor(tag.match(/@type\s+\{([^}]+)\}/)?.[1]))
+        const type = tag.match(/@type\s+\{([^}]+)\}/)?.[1]
+        Object.assign(schema, getTypeDescriptor(type))
+        const typedef = tags.find(t => t.match(/@typedef\s+\{([^}]+)\} (.*)/)?.[2] === type)
+        if (typedef) {
+          schema.markdownType = type
+          schema.tsType = typedef.match(/@typedef\s+\{([^}]+)\}/)?.[1]
+        }
         continue
       }
       schema.tags.push(tag.trim())

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,12 @@ export type JSType =
 export type ResolveFn = ((value: any, get: (key: string) => any) => JSValue)
 
 export interface TypeDescriptor {
-  type?: JSType | JSType[] | string | string[]
+  /** Used internally to handle schema types */
+  type?: JSType | JSType[]
+  /** Fully resolved correct TypeScript type for generated TS declarations */
+  tsType?: string
+  /** Human-readable type description for use in generated documentation */
+  markdownType?: string
   items?: TypeDescriptor | TypeDescriptor[]
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,8 +123,12 @@ export function isJSType (val: unknown): val is JSType {
 const FRIENDLY_TYPE_RE = /typeof import\(['"](?<importName>[^'"]+)['"]\)(\[['"]|\.)(?<firstType>[^'"\s]+)(['"]\])?/g
 
 export function getTypeDescriptor (type: string | JSType): TypeDescriptor {
+  if (!type) {
+    return {}
+  }
+
   let markdownType = type
-  for (const match of type.matchAll(FRIENDLY_TYPE_RE)) {
+  for (const match of type.matchAll(FRIENDLY_TYPE_RE) || []) {
     const { importName, firstType } = match.groups || {}
     if (importName && firstType) {
       markdownType = markdownType.replace(match[0], pascalCase(importName) + pascalCase(firstType))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,15 +87,17 @@ export function mergedTypes (...types: TypeDescriptor[]): TypeDescriptor {
   types = types.filter(Boolean)
   if (types.length === 0) { return {} }
   if (types.length === 1) { return types[0] }
+  const tsTypes = normalizeTypes(types.map(t => t.tsType).flat().filter(Boolean))
   return {
     type: normalizeTypes(types.map(t => t.type).flat().filter(Boolean)),
+    tsType: Array.isArray(tsTypes) ? tsTypes.join(' | ') : tsTypes,
     items: mergedTypes(...types.map(t => t.items).flat().filter(Boolean))
   }
 }
 
-export function normalizeTypes (val: string[]) {
+export function normalizeTypes<T extends string> (val: T[]) {
   const arr = unique(val.filter(str => str))
-  if (!arr.length || arr.includes('any')) { return undefined }
+  if (!arr.length || arr.includes('any' as any)) { return undefined }
   return (arr.length > 1) ? arr : arr[0]
 }
 
@@ -108,5 +110,18 @@ export function cachedFn (fn) {
       resolved = true
     }
     return val
+  }
+}
+
+const jsTypes: JSType[] = ['string', 'number', 'bigint', 'boolean', 'symbol', 'function', 'object', 'any', 'array']
+
+export function isJSType (val: unknown): val is JSType {
+  return jsTypes.includes(val as any)
+}
+
+export function getTypeDescriptor (type: string | JSType) {
+  return {
+    ...isJSType(type) ? { type } : {},
+    tsType: type
   }
 }

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -15,7 +15,7 @@ describe('transform (functions)', () => {
           type: 'string'
         }, {
           name: 'date',
-          type: 'Date'
+          tsType: 'Date'
         }, {
           name: 'append',
           optional: true,
@@ -42,7 +42,7 @@ describe('transform (functions)', () => {
           }
         }, {
           name: 'append',
-          type: 'false'
+          tsType: 'false'
         }]
       }
     })
@@ -59,7 +59,7 @@ describe('transform (functions)', () => {
         type: 'function',
         args: [],
         returns: {
-          type: 'void'
+          tsType: 'void'
         }
       }
     })
@@ -84,7 +84,7 @@ describe('transform (functions)', () => {
           { name: 'b', type: 'number' }
         ],
         returns: {
-          type: 'void'
+          tsType: 'void'
         }
       }
     })
@@ -193,7 +193,7 @@ describe('transform (jsdoc)', () => {
         $schema: {
           title: '',
           description: '',
-          type: "'src' | 'root'"
+          tsType: "'src' | 'root'"
         }
       }
     })

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -212,6 +212,29 @@ describe('transform (jsdoc)', () => {
     })
   })
 
+  it('correctly parses @typedef tags', () => {
+    const result = transform(`
+      export default {
+        /**
+         * @typedef {'src' | 'root'} HumanReadable
+         * @type {HumanReadable}
+         */
+        srcDir: 'src',
+      }
+    `)
+    expectCodeToMatch(result, /export default ([\s\S]*)$/, {
+      srcDir: {
+        $default: 'src',
+        $schema: {
+          title: '',
+          description: '',
+          tsType: "'src' | 'root'",
+          markdownType: 'HumanReadable'
+        }
+      }
+    })
+  })
+
   it('correctly parses only tags', () => {
     const result = transform(`
       export default {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -184,7 +184,11 @@ describe('transform (jsdoc)', () => {
         /**
          * @type {'src' | 'root'}
          */
-        srcDir: 'src'
+        srcDir: 'src',
+        /**
+         * @type {null | typeof import('path').posix | typeof import('net')['Socket']['PassThrough']}
+         */
+        posix: null
       }
     `)
     expectCodeToMatch(result, /export default ([\s\S]*)$/, {
@@ -194,6 +198,15 @@ describe('transform (jsdoc)', () => {
           title: '',
           description: '',
           tsType: "'src' | 'root'"
+        }
+      },
+      posix: {
+        $default: null,
+        $schema: {
+          title: '',
+          description: '',
+          tsType: "null | typeof import('path').posix | typeof import('net')['Socket']['PassThrough']",
+          markdownType: 'null | PathPosix | NetSocket[\'PassThrough\']'
         }
       }
     })

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -66,6 +66,7 @@ interface Untyped {
           }, {
             name: 'append',
             type: 'boolean',
+            tsType: 'false',
             optional: true
           }]
         }
@@ -74,7 +75,7 @@ interface Untyped {
 
     expect(types).toBe(`
 interface Untyped {
-   add: (test?: Array<string | number>, append?: boolean) => any,
+   add: (test?: Array<string | number>, append?: false) => any,
 }
 `.trim())
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4482,6 +4482,11 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
+scule@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/scule/-/scule-0.2.1.tgz#0c1dc847b18e07219ae9a3832f2f83224e2079dc"
+  integrity sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==
+
 "semver@2 || 3 || 4 || 5":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4482,7 +4482,7 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scule@^0.2.1:
+scule@latest:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/scule/-/scule-0.2.1.tgz#0c1dc847b18e07219ae9a3832f2f83224e2079dc"
   integrity sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==


### PR DESCRIPTION
This PR splits out `tsType` and `markdownType` (i.e. a human-readable type) from the schema `type`, because likely we can do useful operations on objects/arrays and other types when they are distilled into a smaller subset of possible types.

To produce `markdownType`, this PR uses `@typedef` to provide human-readable `markdownType` (and also provide a default markdown gloss for `typeof import('some-library')['sometype']` or `typeof import('some-library').sometype`.

Example:
```js
export const config = {
    /**
     * @typedef {false | true | 0 | 1} Booleanish
     * @type {Booleanish}
     */
    checked: false,
    dimensions: {
        /** @type {10 | 20} */
        width: 10,
        /** height in px */
        height: 10
    },
}
```

See [**playground**](https://c8650c82.untyped.pages.dev/#eyJlZGl0b3JUYWIiOiJyZWZlcmVuY2UiLCJvdXRwdXRUYWIiOiJ0eXBlcyIsInJlZiI6ImV4cG9ydCBjb25zdCBjb25maWcgPSB7XG4gICAgLyoqXG4gICAgICogQHR5cGVkZWYge2ZhbHNlIHwgdHJ1ZSB8IDAgfCAxfSBCb29sZWFuaXNoXG4gICAgICogQHR5cGUge0Jvb2xlYW5pc2h9XG4gICAgICovXG4gICAgY2hlY2tlZDogZmFsc2UsXG4gICAgZGltZW5zaW9uczoge1xuICAgICAgICAvKiogQHR5cGUgezEwIHwgMjB9ICovXG4gICAgICAgIHdpZHRoOiAxMCxcbiAgICAgICAgLyoqIGhlaWdodCBpbiBweCAqL1xuICAgICAgICBoZWlnaHQ6IDEwXG4gICAgfSxcbiAgICAvKipcbiAgICAgKiBAdHlwZSB7dHlwZW9mIGltcG9ydCgncGF0aCcpLnBvc2l4fVxuICAgICAqL1xuICAgIHBhdGg6IG51bGxcbn0iLCJpbnB1dCI6ImV4cG9ydCBjb25zdCBjb25maWcgPSB7XG4gICAgbmFtZTogJ2ZvbycsXG4gICAgZGltZW5zaW9uczoge1xuICAgICAgICBoZWlnaHQ6IDI1XG4gICAgfSxcbiAgICB0YWdzOiBbJ2N1c3RvbSddXG59In0=).