### PR TITLE
feat!: extract top-level type imports

### DIFF
--- a/src/generator/dts.ts
+++ b/src/generator/dts.ts
@@ -59,7 +59,7 @@ function extractTypeImports (declarations: string) {
 }
 
 export function generateTypes (schema: Schema, name: string = 'Untyped') {
-  return extractTypeImports(`interface ${name} {\n  ` + _genTypes(schema, ' ').join('\n ') + '\n}')
+  return extractTypeImports(`export interface ${name} {\n  ` + _genTypes(schema, ' ').join('\n ') + '\n}')
 }
 
 function _genTypes (schema: Schema, spaces: string): string[] {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -79,4 +79,46 @@ interface Untyped {
 }
 `.trim())
   })
+
+  it('extracts type imports to top-level', () => {
+    const types = generateTypes(resolveSchema({
+      test: {
+        foo: {
+          $schema: {
+            tsType: 'typeof import("vue").VueConfig'
+          }
+        },
+        bar: {
+          $schema: {
+            tsType: 'typeof import("vue")["VueConfig"]'
+          }
+        },
+        baz: {
+          $schema: {
+            tsType: 'typeof import("vue").OtherImport'
+          }
+        },
+        quf: {
+          $schema: {
+            tsType: 'typeof import("other-lib").VueConfig'
+          }
+        }
+      }
+    }))
+    expect(types).toBe(`
+import type { VueConfig, OtherImport } from 'vue'
+import type { VueConfig as VueConfig0 } from 'other-lib'
+interface Untyped {
+   test: {
+    foo: VueConfig,
+
+    bar: VueConfig,
+
+    baz: OtherImport,
+
+    quf: VueConfig0,
+  },
+}
+`.trim())
+  })
 })

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -14,7 +14,7 @@ describe('resolveSchema', () => {
       }
     }))
     expect(types).toBe(`
-interface Untyped {
+export interface Untyped {
    test: {
     /**
      * Test
@@ -35,7 +35,7 @@ interface Untyped {
     }))
 
     expect(types).toBe(`
-interface Untyped {
+export interface Untyped {
    empty: Array<any>,
 
   /** @default [1,2,3] */
@@ -74,7 +74,7 @@ interface Untyped {
     }))
 
     expect(types).toBe(`
-interface Untyped {
+export interface Untyped {
    add: (test?: Array<string | number>, append?: false) => any,
 }
 `.trim())
@@ -108,7 +108,7 @@ interface Untyped {
     expect(types).toBe(`
 import type { VueConfig, OtherImport } from 'vue'
 import type { VueConfig as VueConfig0 } from 'other-lib'
-interface Untyped {
+export interface Untyped {
    test: {
     foo: VueConfig,
 


### PR DESCRIPTION
Note: for `unbuild` compatibility, will requires change (currently produces `export import type { ComponentsOptions } from '../src'`)