### PR TITLE
fix: check for object type when recursing into a property

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,9 @@ export function setValue (obj: Record<string, any>, path: string, val: any) {
   const keys = path.split('.')
   const _key = keys.pop()
   for (const key of keys) {
+    if (!obj || typeof obj !== 'object') {
+      return
+    }
     if (!(key in obj)) {
       obj[key] = {}
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,9 @@ export function setValue (obj: Record<string, any>, path: string, val: any) {
     obj = obj[key]
   }
   if (_key) {
+    if (!obj || typeof obj !== 'object') {
+      return
+    }
     obj[_key] = val
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,7 +66,7 @@ export function setValue (obj: Record<string, any>, path: string, val: any) {
 
 export function getValue <V = any> (obj: Record<string, any>, path: string) {
   for (const key of path.split('.')) {
-    if (!(key in obj)) {
+    if (!obj || typeof obj !== 'object' || !(key in obj)) {
       return undefined
     }
     obj = obj[key]

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { getValue, setValue } from '../src/utils'
+
+describe('getValue', () => {
+  it('handles inaccessible properties', () => {
+    const fixture = { top: false, test: { other: false, thing: { value: 'foo' } } }
+    expect(getValue(fixture, 'test.thing.value')).toBe('foo')
+    expect(getValue(fixture, 'test.other.value')).toBe(undefined)
+    expect(getValue(fixture, 'top.other.value')).toBe(undefined)
+  })
+})
+
+describe('setValue', () => {
+  it('handles inaccessible properties', () => {
+    const fixture = { test: { other: false, thing: { value: 'foo' } } }
+    setValue(fixture, 'test.thing.value', 'bar')
+    expect(fixture.test.thing.value).toBe('bar')
+    setValue(fixture, 'test.other.value', 'ab')
+    expect(fixture.test.other).toBe(false)
+  })
+})


### PR DESCRIPTION
When an intermediate value is `false` or something else, we have an issue when using `getValue`.

E.g. `build.stats` is either `false` or `{ excludeAssets: [] }`, then if we did `get('build.stats.excludeAssets')` this would currently fail with the message:

```
TypeError: Cannot use 'in' operator to search for 'excludeAssets' in false
 ❯ getValue node_modules/untyped/dist/chunks/utils.mjs:46:15
 ❯ _resolveSchema node_modules/untyped/dist/index.mjs:23:38
 ❯ _resolveSchema node_modules/untyped/dist/index.mjs:39:32
 ❯ _resolveSchema node_modules/untyped/dist/index.mjs:39:32
 ❯ _resolveSchema node_modules/untyped/dist/index.mjs:39:32
 ❯ resolveSchema node_modules/untyped/dist/index.mjs:5:18
 ❯ applyDefaults node_modules/untyped/dist/index.mjs:66:3
```