### PR TITLE
docs: fix usage of generateMarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ interface Untyped {
 ```js
 import { resolveSchema, generateTypes, generateMarkdown } from 'untyped'
 
-const markdown = generateMarkdown(generateTypes(resolveSchema(defaultPlanet)))
+const markdown = generateMarkdown(resolveSchema(defaultPlanet))
 ```
 
 Output:


### PR DESCRIPTION
When I found that the usage was wrong, I went to the source code and found that there was one more `generateTypes` here. 😳