### PR TITLE
docs: tidy up and improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@
 ## Install
 
 ```sh
+# npm
+npm i untyped
+
+# yarn
 yarn add untyped
-```
 
-```sh
+# pnpm
 pnpm add untyped
-```
-
-```sh
-npm i --save untyped
 ```
 
 ## Usage
@@ -90,9 +89,6 @@ Output:
   "type": "object"
 }
 ```
-
-<a name="generating-types"></a>
-
 ### `generateTypes`
 
 ```js
@@ -121,8 +117,6 @@ interface Untyped {
 }
 ```
 
-<a name="generating-markdown"></a>
-
 ### `generateMarkdown`
 
 ```js
@@ -150,8 +144,6 @@ Output:
 - **Type**: `array`
 - **Default**: `["moon"]`
 ```
-
----
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,12 @@ Output:
 - **Default**: `["moon"]`
 ```
 
-## Contributing
+## 💻 Development
 
-- Clone repository
-- Install dependencies with `yarn install`
+- Clone this repository
+- Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable` (use `npm i -g corepack` for Node.js < 16.10)
+- Install dependencies using `yarn install`
+- Run interactive tests using `yarn dev`
 - Use `yarn web` to start playground website
 - Use `yarn test` before push to ensure all tests and lint checks passing
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,25 @@
 [![Codecov][codecov-src]][codecov-href]
 [![bundle][bundle-src]][bundle-href]
 
-
-
 **▶️ Check [online playground](https://untyped.unjs.io)**
 
-
-## Usage
-
-### Install package
-
-Install `untyped` npm package:
+## Install
 
 ```sh
 yarn add untyped
-# or
-npm i untyped
 ```
 
-### Define reference object
+```sh
+pnpm add untyped
+```
 
-First we have to define a reference object that describes types, defaults and normalizer
+```sh
+npm i --save untyped
+```
+
+## Usage
+
+First we have to define a reference object that describes types, defaults, and a `$resolve` method (normalizer).
 
 ```js
 const defaultPlanet = {
@@ -45,7 +44,11 @@ const defaultPlanet = {
 }
 ```
 
-### Resolving Schema
+## API
+
+<a name="resolving-schema"></a>
+
+### `resolveSchema`
 
 ```js
 import { resolveSchema } from 'untyped'
@@ -88,8 +91,9 @@ Output:
 }
 ```
 
-### Generating types
+<a name="generating-types"></a>
 
+### `generateTypes`
 
 ```js
 import { resolveSchema, generateTypes } from 'untyped'
@@ -117,11 +121,12 @@ interface Untyped {
 }
 ```
 
-### Generating markdown
+<a name="generating-markdown"></a>
 
+### `generateMarkdown`
 
 ```js
-import { resolveSchema, generateTypes, generateMarkdown } from 'untyped'
+import { resolveSchema, generateMarkdown } from 'untyped'
 
 const markdown = generateMarkdown(resolveSchema(defaultPlanet))
 ```
@@ -146,7 +151,9 @@ Output:
 - **Default**: `["moon"]`
 ```
 
-## Contribution
+---
+
+## Contributing
 
 - Clone repository
 - Install dependencies with `yarn install`

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ const defaultPlanet = {
 
 ## API
 
-<a name="resolving-schema"></a>
-
 ### `resolveSchema`
 
 ```js


### PR DESCRIPTION
- install section: split yarn and npm codeblocks, add pnpm
- minor housekeeping in **Usage** section
- move methods to **API** section (with anchor tags for backwards compat. w/ old headings)
- remove useless import of `generateTypes` from `generateMarkdown` section
- add a thematic break above **Contributing** section