### PR TITLE
feat: schema loader and `untyped` cli

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -5,10 +5,12 @@ export default defineBuildConfig({
   entries: [
     "./src/index",
     "./src/loader/babel",
-    "./src/loader/transform"
+    "./src/loader/transform",
+    "./src/loader/loader",
+    "./src/cli",
   ],
   rollup: {
     // inlineDependencies: true,
-    emitCJS: true
-  }
+    emitCJS: true,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -20,10 +20,18 @@
       "import": "./dist/transform.mjs",
       "require": "./dist/transform.cjs",
       "types": "./dist/transform.d.ts"
+    },
+    "./loader": {
+      "types": "./dist/loader.d.ts",
+      "import": "./dist/loader.mjs",
+      "require": "./dist/loader.cjs"
     }
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "untyped": "./dist/cli.mjs"
+  },
   "files": [
     "dist"
   ],
@@ -34,6 +42,7 @@
     "prepack": "pnpm build",
     "release": "pnpm test && standard-version && git push --follow-tags && npm publish",
     "test": "pnpm lint && vitest run --coverage",
+    "untyped": "jiti ./src/cli.ts",
     "web": "nuxi dev web",
     "web:build": "nuxi generate web"
   },
@@ -41,6 +50,9 @@
     "@babel/core": "^7.21.3",
     "@babel/standalone": "^7.21.3",
     "@babel/types": "^7.21.3",
+    "defu": "^6.1.2",
+    "jiti": "^1.18.2",
+    "mri": "^1.2.0",
     "scule": "^1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,12 +10,15 @@ specifiers:
   '@types/node': ^18.15.10
   '@vitest/coverage-c8': ^0.29.7
   '@vue/compiler-sfc': ^3.2.47
+  defu: ^6.1.2
   eslint: ^8.36.0
   eslint-config-unjs: ^0.1.0
   hljs: ^6.2.3
+  jiti: ^1.18.2
   json-schema: ^0.4.0
   marked: ^4.3.0
   monaco-editor: ^0.36.1
+  mri: ^1.2.0
   nuxt: ^3.3.2
   nuxt-windicss: ^2.6.0
   prettier: ^2.8.7
@@ -30,6 +33,9 @@ dependencies:
   '@babel/core': 7.21.3
   '@babel/standalone': 7.21.3
   '@babel/types': 7.21.3
+  defu: 6.1.2
+  jiti: 1.18.2
+  mri: 1.2.0
   scule: 1.0.0
 
 devDependencies:
@@ -2703,7 +2709,6 @@ packages:
 
   /defu/6.1.2:
     resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
-    dev: true
 
   /delegates/1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -4451,7 +4456,6 @@ packages:
   /jiti/1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
-    dev: true
 
   /js-sdsl/4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
@@ -4960,7 +4964,6 @@ packages:
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-    dev: true
 
   /mrmime/1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import mri from "mri";
+
+async function main() {
+  const args = mri(process.argv.slice(2));
+  const [action, entryPath] = args._;
+
+  if (action !== "load" || !entryPath) {
+    console.error("Usage: untyped load <entryPath> [--write]");
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
+
+  const { loadSchema } = await import("./loader/loader");
+  const schema = await loadSchema(entryPath, {});
+  if (args.write) {
+    const json = JSON.stringify(schema, null, 2);
+    const outfile = resolve(
+      process.cwd(),
+      args.write === true ? "schema.json" : args.write
+    );
+    await writeFile(outfile, json);
+  } else {
+    console.log(schema);
+  }
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await
+main().catch((error) => {
+  console.error(error);
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(1);
+});

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -1,0 +1,38 @@
+import jiti from "jiti";
+import defu from "defu";
+import { resolveSchema } from "../schema";
+import type { Schema } from "../types";
+import untypedPlugin from "./babel";
+
+// TODO: https://github.com/unjs/jiti/issues/132
+type JITIOptions = Parameters<typeof jiti>[1];
+
+export interface LoaderOptions {
+  jiti?: JITIOptions;
+  defaults?: Record<string, any>;
+}
+
+export async function loadSchema(
+  entryPath: string,
+  options: LoaderOptions
+): Promise<Schema> {
+  const _jitiRequire = jiti(
+    process.cwd(),
+    defu(options.jiti, {
+      esmResolve: true,
+      interopDefault: true,
+      transformOptions: {
+        babel: {
+          plugins: [untypedPlugin],
+        },
+      },
+    })
+  );
+
+  const resolvedEntryPath = _jitiRequire.resolve(entryPath);
+  const rawSchema = _jitiRequire(resolvedEntryPath);
+
+  const schema = await resolveSchema(rawSchema, options.defaults);
+
+  return schema;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,12 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "strict": false,
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
This PR adds two new features:

- `loadSchema` from `untyped/loader` using jiti+babel plugin to load schema from source
- `untyped load <path> [--write]` CLI to easily load source