### PR TITLE
fix: broken types with array literal and object entries

### DIFF
--- a/src/generator/dts.ts
+++ b/src/generator/dts.ts
@@ -179,6 +179,10 @@ function getTsType(
     return "any";
   }
   if (Array.isArray(type.type)) {
+    // if we're mixing objects with literals then we just revert to any array input
+    if (type.type.length > 1 && type.type.includes("object")) {
+      return 'any'
+    }
     return type.type.map((t) => TYPE_MAP[t]).join("|");
   }
   if (type.type === "array") {

--- a/src/generator/dts.ts
+++ b/src/generator/dts.ts
@@ -179,13 +179,15 @@ function getTsType(
     return "any";
   }
   if (Array.isArray(type.type)) {
-    return type.type.map((t) => {
-      // object is typed to an empty string by default, we need to type as object
-      if (t === 'object' && type.type.length > 1) {
-        return `{\n` + _genTypes(type, " ", opts).join("\n") + `\n}`;
-      }
-      return TYPE_MAP[t]
-    }).join("|");
+    return type.type
+      .map((t) => {
+        // object is typed to an empty string by default, we need to type as object
+        if (t === "object" && type.type.length > 1) {
+          return `{\n` + _genTypes(type, " ", opts).join("\n") + `\n}`;
+        }
+        return TYPE_MAP[t];
+      })
+      .join("|");
   }
   if (type.type === "array") {
     return `Array<${getTsType(type.items, opts)}>`;

--- a/src/generator/dts.ts
+++ b/src/generator/dts.ts
@@ -179,11 +179,13 @@ function getTsType(
     return "any";
   }
   if (Array.isArray(type.type)) {
-    // if we're mixing objects with literals then we just revert to any array input
-    if (type.type.length > 1 && type.type.includes("object")) {
-      return 'any'
-    }
-    return type.type.map((t) => TYPE_MAP[t]).join("|");
+    return type.type.map((t) => {
+      // object is typed to an empty string by default, we need to type as object
+      if (t === 'object' && type.type.length > 1) {
+        return `{\n` + _genTypes(type, " ", opts).join("\n") + `\n}`;
+      }
+      return TYPE_MAP[t]
+    }).join("|");
   }
   if (type.type === "array") {
     return `Array<${getTsType(type.items, opts)}>`;

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -206,12 +206,12 @@ export interface Untyped {
     `);
   });
 
-  it('array - literal and object entries', async() => {
+  it("array - literal and object entries", async () => {
     const schema = generateTypes(
-        await resolveSchema(({
-          foo: { bar: ['first', 'second', { third: true }] },
-        }))
-    )
+      await resolveSchema({
+        foo: { bar: ["first", "second", { third: true }] },
+      })
+    );
     expect(schema).toMatchInlineSnapshot(`
       "export interface Untyped {
        foo: {
@@ -221,6 +221,6 @@ export interface Untyped {
         }>,
        },
       }"
-    `)
-  })
+    `);
+  });
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -216,10 +216,11 @@ export interface Untyped {
       "export interface Untyped {
        foo: {
         /** @default [\\"first\\",\\"second\\",{\\"third\\":true}] */
-        bar: Array<any>,
+        bar: Array<string|{
+         [key: string]: any
+        }>,
        },
       }"
     `)
   })
-
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -21,9 +21,9 @@ describe("resolveSchema", () => {
        test: {
         /**
          * Test
-         * 
+         *
          * this is test
-         * 
+         *
          * @default \\"test value\\"
         */
         foo: string,
@@ -106,13 +106,13 @@ describe("resolveSchema", () => {
        manual?: Array<{
         /**
          * This is foo prop
-         * 
+         *
         */
         foo: number,
 
         /**
          * This is bar prop
-         * 
+         *
         */
         bar?: number,
        }>,
@@ -205,4 +205,21 @@ export interface Untyped {
       }"
     `);
   });
+
+  it('array - literal and object entries', async() => {
+    const schema = generateTypes(
+        await resolveSchema(({
+          foo: { bar: ['first', 'second', { third: true }] },
+        }))
+    )
+    expect(schema).toMatchInlineSnapshot(`
+      "export interface Untyped {
+       foo: {
+        /** @default [\\"first\\",\\"second\\",{\\"third\\":true}] */
+        bar: Array<any>,
+       },
+      }"
+    `)
+  })
+
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -21,9 +21,9 @@ describe("resolveSchema", () => {
        test: {
         /**
          * Test
-         *
+         * 
          * this is test
-         *
+         * 
          * @default \\"test value\\"
         */
         foo: string,
@@ -106,13 +106,13 @@ describe("resolveSchema", () => {
        manual?: Array<{
         /**
          * This is foo prop
-         *
+         * 
         */
         foo: number,
 
         /**
          * This is bar prop
-         *
+         * 
         */
         bar?: number,
        }>,


### PR DESCRIPTION
## Issue

https://github.com/harlan-zw/nuxt-og-image/issues/48

When we mix literal types with objects, then the generated TS is broken.

## Solution

The reason why this fails is because the `object` type is mapped to an empty string. We need logic to handle this edge-case.

We explicitly check for mixing literals with objects and revert to the object to the default object type.