### PR TITLE
fix: tighten schema definition types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -61,11 +61,11 @@ export interface InputObject {
   $schema?: Schema;
   $resolve?: ResolveFn;
   $default?: any;
-  [key: string]: any;
+  [key: string]: JSValue | InputObject;
 }
 
 export type InputValue = InputObject | JSValue;
 
 export type SchemaDefinition = {
-  [x: string]: JSValue | InputObject | SchemaDefinition;
+  [x: string]: JSValue | InputObject;
 };


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/22340

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We currently have an issue with newer typescript versions whereby `$resolve` (and similar 'magic' keys) are not being typed correctly because they could also be equally well typed with `any`. This makes a change to SchemaDefinition types that removes the `any` signature in favour of explicit `JSValue` types (but only for keys that do not match `$resolve`, etc.).

This increases type safety and may result in an error when an `unknown` property is assigned to a schema value. But nevertheless this is worth testing to ensure no (unintended) regressions.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
