### PR TITLE
feat: add zod define schema support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "defu": "^6.1.2",
     "jiti": "^1.19.1",
     "mri": "^1.2.0",
-    "scule": "^1.0.0"
+    "scule": "^1.0.0",
+    "zod": "^3.21.4",
+    "zod-to-json-schema": "^3.21.4"
   },
   "devDependencies": {
     "@babel/template": "^7.22.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ dependencies:
   scule:
     specifier: ^1.0.0
     version: 1.0.0
+  zod:
+    specifier: ^3.21.4
+    version: 3.21.4
+  zod-to-json-schema:
+    specifier: ^3.21.4
+    version: 3.21.4(zod@3.21.4)
 
 devDependencies:
   '@babel/template':
@@ -7363,3 +7369,15 @@ packages:
       compress-commons: 4.1.1
       readable-stream: 3.6.2
     dev: true
+
+  /zod-to-json-schema@3.21.4(zod@3.21.4):
+    resolution: {integrity: sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==}
+    peerDependencies:
+      zod: ^3.21.4
+    dependencies:
+      zod: 3.21.4
+    dev: false
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: false

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,3 +1,5 @@
+import { ZodSchema } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import type { InputObject, InputValue, JSType, JSValue, Schema } from "./types";
 import {
   getType,
@@ -23,16 +25,19 @@ export interface NormalizeSchemaOptions {
 export interface ResolveSchemaOptions extends NormalizeSchemaOptions {}
 
 export async function resolveSchema(
-  obj: InputObject,
+  obj: InputObject | ZodSchema<any> ,
   defaults?: InputObject,
   options: ResolveSchemaOptions = {},
 ): Promise<Schema> {
-  const schema = await _resolveSchema(obj, "", {
-    root: obj,
-    defaults,
-    resolveCache: {},
-    ignoreDefaults: options.ignoreDefaults,
-  });
+  const schema = obj instanceof ZodSchema
+? zodToJsonSchema(obj, "schemaName").definitions.schemaName
+: (await _resolveSchema(obj, "", {
+      root: obj,
+      defaults,
+      resolveCache: {},
+      ignoreDefaults: options.ignoreDefaults,
+    }));
+
   // TODO: Create meta-schema fror superset of Schema interface
   // schema.$schema = 'http://json-schema.org/schema#'
   return schema;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/unjs/untyped/issues/90

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Now `resolveSchema` function supports passing in `ZodSchema` and returning a JSON Schema, by using the [`zod-to-json-schema` package](https://github.com/StefanTerdell/zod-to-json-schema).

<table>
  <tr>
    <th>Zod</th>
    <th>Legacy</th>
  </tr>

  <tr>
    <td>

```ts
const defaultPlanet = z.object({
  name: z.string().default('earth'),
  specs: z.object({
    gravity: z.number().default(9.8)
      .transform(val => Number.parseFloat(String(val))),
    moons: z.array(z.string()).default(['moon'])
      .transform(val => [val].flat())
  })
});
```

</td>
    <td>

```ts
const defaultPlanet = {
  name: 'earth',
  specs: {
    gravity: {
      $resolve: val => Number.parseFloat(val),
      $default: '9.8'
    },
    moons: {
      $resolve: (val = ['moon']) => [val].flat(),
      $schema: {
        title: 'planet moons'
      }
    }
  }
};
```

</td>
  </tr>

  <tr>
    <td>

```json
{
  "type": "object",
  "properties": {
    "name": {
      "type": "string",
      "default": "earth"
    },
    "specs": {
      "type": "object",
      "properties": {
        "gravity": {
          "type": "number",
          "default": 9.8
        },
        "moons": {
          "type": "array",
          "items": {
            "type": "string"
          },
          "default": [
            "moon"
          ]
        }
      },
      "additionalProperties": false
    }
  },
  "required": [
    "specs"
  ],
  "additionalProperties": false
}
```

</td>
    <td>

```json
{
  "id": "#",
  "properties": {
    "name": {
      "type": "string",
      "id": "#name",
      "default": "earth"
    },
    "specs": {
      "id": "#specs",
      "properties": {
        "gravity": {
          "id": "#specs/gravity",
          "default": 9.8,
          "type": "number"
        },
        "moons": {
          "title": "planet moons",
          "id": "#specs/moons",
          "default": [
            "moon"
          ],
          "type": "array",
          "items": {
            "type": "string"
          }
        }
      },
      "type": "object",
      "default": {
        "gravity": 9.8,
        "moons": [
          "moon"
        ]
      }
    }
  },
  "type": "object",
  "default": {
    "name": "earth",
    "specs": {
      "gravity": 9.8,
      "moons": [
        "moon"
      ]
    }
  }
}
```

</td>
  </tr>
</table>

But I haven't written tests on this yet to make sure it works exactly the same way. Before going further, I hope I have not misunderstood the purpose of the issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
