### PR TITLE
fix: respect multines example block

### DIFF
--- a/src/loader/babel.ts
+++ b/src/loader/babel.ts
@@ -210,20 +210,19 @@ const babelPluginUntyped: PluginItem = function (
 
 export default babelPluginUntyped;
 
-function containsIncompleteCodeblock(line = "") {
-  const codeDelimiters = line
-    .split("\n")
-    .filter((line) => line.startsWith("```")).length;
-  return !!(codeDelimiters % 2);
+function isExampleBlock(line = "") {
+  return line.includes("@example");
 }
 
 function clumpLines(lines: string[], delimiters = [" "], separator = " ") {
   const clumps: string[] = [];
   while (lines.length > 0) {
     const line = lines.shift();
+
     if (
       (line && !delimiters.includes(line[0]) && clumps.at(-1)) ||
-      containsIncompleteCodeblock(clumps.at(-1))
+      // Support for example blocks in mutliline comments (last line is an example and next line is not a tag)
+      (isExampleBlock(clumps.at(-1)) && !line.startsWith("@"))
     ) {
       clumps[clumps.length - 1] += separator + line;
     } else {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -326,6 +326,36 @@ describe("transform (jsdoc)", () => {
     });
   });
 
+  it("does not split example without codeblock", () => {
+    const result = transform(`
+      export default {
+        /**
+         * @note This is a note.
+         * @example
+         * export default secretNumber = 42
+         *
+         * export default nothing = null
+         * @type {'src' | 'root'}
+         */
+        srcDir: 'src'
+      }
+    `);
+    expectCodeToMatch(result, /export default ([\S\s]*)$/, {
+      srcDir: {
+        $default: "src",
+        $schema: {
+          title: "",
+          tsType: "'src' | 'root'",
+          description: "",
+          tags: [
+            "@note This is a note.",
+            "@example\nexport default secretNumber = 42\n\nexport default nothing = null",
+          ],
+        },
+      },
+    });
+  });
+
   it("correctly parses type assertion", () => {
     const result = transform(`
       import type { InputObject } from 'untyped'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This PR allow blank lines within example block.

Previously, blank lines was automatically removed unless you use triple ` (backticks) to define the block. Now, you can write

```js
// some code

// some code
```

and it will be rendered as

```js
// some code

// some code
```

Before it was rendered as

```js
// some code
// some code
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
